### PR TITLE
Fixed security vulnerability related to setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ keywords = ["Dynamic Energy Budget", "DEB", "DEBtool"]
 dependencies = [
     'numpy<=1.26.4',
     'pandas>=1.2.0',
-    'tabulate>=0.8.0'
+    'tabulate>=0.9.0',
+    'setuptools>=70.0.0'
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-numpy~=1.26.4
-setuptools~=69.5.1
-tabulate~=0.9.0
+matlabengine>=24.0.0


### PR DESCRIPTION
setuptools version must now be greater than 70.0.0 
requirements.txt now only includes dependency for matlabengine