### PR TITLE
Fixed bug in pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=70.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ['DEBtoolPyIF']
 
 [project]
 name = "DEBtoolPyIF"


### PR DESCRIPTION
pyproject.toml now explicitly mentions the package to be built build now requires setuptools>=70.0